### PR TITLE
Add email headers to ParsedEmail struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,7 +2780,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "relayer-utils"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2792,6 +2792,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "lazy_static",
+ "mailparse",
  "neon",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"
@@ -45,6 +45,7 @@ slog-term = "2.9.0"
 slog-json = "2.6.1"
 lazy_static = "1.4"
 file-rotate = "0.7.5"
+mailparse = "0.15.0"
 
 [dependencies.neon]
 version = "0.10"

--- a/src/parse_email.rs
+++ b/src/parse_email.rs
@@ -125,8 +125,8 @@ impl ParsedEmail {
     pub fn get_invitation_code(&self) -> Result<String> {
         let regex_config =
             serde_json::from_str(include_str!("../regexes/invitation_code.json")).unwrap();
-        let idxes = extract_substr_idxes(&self.canonicalized_body, &regex_config)?[0];
-        let str = self.canonicalized_body[idxes.0..idxes.1].to_string();
+        let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config)?[0];
+        let str = self.canonicalized_header[idxes.0..idxes.1].to_string();
         Ok(str)
     }
 


### PR DESCRIPTION
Added email_headers to the ParsedEmail struct. It contains all the headers of the email as HashMap.
Optionally we could only parse headers we need and set that in the .env file.