### PR TITLE
Dimidumo/zk 849 add external input to proof creation in sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 **/.DS_Store
 npm-debug.log*
 pkg
+
+tests/outputs

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -598,4 +598,69 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_generate_regex_inputs_with_external_inputs() -> Result<()> {
+        // Get the test file path relative to the project root
+        let test_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join("test.eml");
+
+        let email = std::fs::read_to_string(test_file)?;
+
+        let mut decomposed_regexes = Vec::new();
+        let part_1 = RegexPartConfig {
+            is_public: false,
+            regex_def: "Hi".to_string(),
+        };
+        let part_2 = RegexPartConfig {
+            is_public: true,
+            regex_def: "!".to_string(),
+        };
+
+        decomposed_regexes.push(DecomposedRegex {
+            parts: vec![part_1, part_2],
+            name: "hi".to_string(),
+            max_length: 64,
+            location: "body".to_string(),
+        });
+
+        let external_inputs = vec![ExternalInput {
+            name: "address".to_string(),
+            value: Some("testerman@zkemail.com".to_string()),
+            max_length: 64,
+        }];
+
+        let input = generate_circuit_inputs_with_decomposed_regexes_and_external_inputs(
+            &email,
+            decomposed_regexes,
+            external_inputs,
+            CircuitInputWithDecomposedRegexesAndExternalInputsParams {
+                max_body_length: 2816,
+                max_header_length: 1024,
+                ignore_body_hash_check: false,
+                remove_soft_lines_breaks: true,
+                sha_precompute_selector: None,
+            },
+        )
+        .await?;
+
+        // Save the input to a file in the test output directory
+        let output_file = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("outputs")
+            .join("input.json");
+
+        // Create the output directory if it doesn't exist
+        if let Some(parent) = output_file.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Save the input to a file
+        let input_str = serde_json::to_string_pretty(&input)?;
+        std::fs::write(output_file, input_str)?;
+
+        Ok(())
+    }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -131,15 +131,15 @@ pub async fn generateCircuitInputsWithDecomposedRegexesAndExternalInputs(
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| async move {
         // Deserialize decomposed_regexes
         let decomposed_regexes: Vec<DecomposedRegex> = from_value(decomposed_regexes)
-            .map_err(|_| String::from("Invalid decomposed_regexes input"))?;
+            .map_err(|e| format!("Invalid decomposed_regexes input: {}", e))?;
 
         // Deserialize external_inputs
         let external_inputs: Vec<ExternalInput> = from_value(external_inputs)
-            .map_err(|_| String::from("Invalid external_inputs input"))?;
+            .map_err(|e| format!("Invalid external_inputs input: {}", e))?;
 
         // Deserialize params
         let params: CircuitInputWithDecomposedRegexesAndExternalInputsParams =
-            from_value(params).map_err(|_| String::from("Invalid params input"))?;
+            from_value(params).map_err(|e| format!("Invalid params input: {}", e))?;
 
         // Call the async function and await the result
         let circuit_inputs = generate_circuit_inputs_with_decomposed_regexes_and_external_inputs(

--- a/ts_tests/circuit_intput.ts
+++ b/ts_tests/circuit_intput.ts
@@ -6,9 +6,8 @@ import { readFile } from "fs/promises";
 describe("generateCircuitInputsWithDecomposedRegexesAndExternalInputs test suite", async () => {
   await init();
   const helloEml = await readFile("tests/fixtures/test.eml", "utf-8");
-  console.log("got eml: ", helloEml);
 
-  test("Should parse valid email", async () => {
+  test("Should create circuit inputs", async () => {
     const decomposedRegexes = [
       {
         parts: [
@@ -42,7 +41,50 @@ describe("generateCircuitInputsWithDecomposedRegexesAndExternalInputs test suite
       [],
       params
     );
-    console.log("inputs: ", inputs);
-    // expect(parsedEmail).not.toBeUndefined();
+    expect(inputs).toBeDefined();
+  });
+
+  test("Should create circuit inputs with external inputs", async () => {
+    const decomposedRegexes = [
+      {
+        parts: [
+          {
+            is_public: true,
+            regex_def: "Hi",
+          },
+          {
+            is_public: true,
+            regex_def: "!",
+          },
+        ],
+        name: "hi",
+        maxLength: 64,
+        location: "body",
+      },
+    ];
+
+    const externalInputs = [
+      {
+        name: "address",
+        maxLength: 64,
+        value: "tester@zkemail.com"
+      }
+    ]
+
+    const params = {
+      maxHeaderLength: 2816,
+      maxBodyLength: 1024,
+      ignoreBodyHashCheck: false,
+      removeSoftLinesBreaks: true,
+      // sha_precompute_selector
+    };
+
+    const inputs = await generateCircuitInputsWithDecomposedRegexesAndExternalInputs(
+      helloEml,
+      decomposedRegexes,
+      externalInputs,
+      params
+    );
+    expect(inputs).toBeDefined();
   });
 });


### PR DESCRIPTION
## Description
Add tests for input creation with external inputs. Add error handling for wasm bindings

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules