### PR TITLE
Rutefig/reg 473 fix testdecomposedregex in sdk and relayerutils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ tests/fixtures/confidential*
 
 
 .claude
-.thoughts
+thoughts/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ pkg
 
 tests/outputs
 tests/fixtures/confidential*
+
+
+.claude
+.thoughts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.62-15"
+version = "0.4.62-16"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.62-14"
+version = "0.4.62-15"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,15 +2202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,16 +2400,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minicov"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
-dependencies = [
- "cc",
- "walkdir",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -3329,6 +3310,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "ethers",
+ "fancy-regex",
  "file-rotate",
  "halo2curves",
  "hex",
@@ -3355,10 +3337,10 @@ dependencies = [
  "slog-json",
  "slog-term",
  "sp1-verifier",
+ "thiserror 1.0.69",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "zk-regex-apis",
  "zk-regex-compiler",
 ]
 
@@ -4816,30 +4798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-test"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
-dependencies = [
- "js-sys",
- "minicov",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-test-macro"
-version = "0.3.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5363,23 +5321,6 @@ dependencies = [
  "sha1",
  "time",
  "zstd",
-]
-
-[[package]]
-name = "zk-regex-apis"
-version = "2.3.2"
-source = "git+https://github.com/zkemail/zk-regex.git#4fb1bda1af71123f57f4877c29ebcb9004266fd8"
-dependencies = [
- "console_error_panic_hook",
- "fancy-regex",
- "itertools 0.13.0",
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.62-13"
+version = "0.4.62-14"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.62-12"
+version = "0.4.62-13"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,11 @@ crate-type = ["rlib", "cdylib"]
 itertools = "0.10.3"
 serde_json = "1.0.95"
 serde = { version = "1.0.159", features = ["derive"] }
-zk-regex-apis = { git = "https://github.com/zkemail/zk-regex.git" }
-zk-regex-compiler = { git = "https://github.com/zkemail/zk-regex.git", rev = "35014c2bff69115bb92be2dc2c9b006fa69a6649"}
+zk-regex-compiler = { git = "https://github.com/zkemail/zk-regex.git", rev = "35014c2bff69115bb92be2dc2c9b006fa69a6649" }
 hex = "0.4.3"
 anyhow = "1.0.75"
+thiserror = "1.0"
+fancy-regex = "0.13.0"
 halo2curves = { git = "https://github.com/privacy-scaling-explorations/halo2curves.git", rev = "8771fe5a5d54fc03e74dbc8915db5dad3ab46a83", default-features = false }
 poseidon-rs = { git = "https://github.com/zkemail/poseidon-rs.git", version = "1.0.0" }
 rand_core = { version = "0.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.4.62-14"
+version = "0.4.62-15"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.4.62-13"
+version = "0.4.62-14"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.4.62-12"
+version = "0.4.62-13"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.4.62-15"
+version = "0.4.62-16"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wasm:postbuild": "node build.js",
     "build": "npm run wasm:build && npm run wasm:postbuild"
   },
-  "version": "0.4.66-7",
+  "version": "0.4.66-8",
   "devDependencies": {
     "@types/bun": "latest",
     "prettier": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wasm:postbuild": "node build.js",
     "build": "npm run wasm:build && npm run wasm:postbuild"
   },
-  "version": "0.4.66-4",
+  "version": "0.4.66-5",
   "devDependencies": {
     "@types/bun": "latest",
     "prettier": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wasm:postbuild": "node build.js",
     "build": "npm run wasm:build && npm run wasm:postbuild"
   },
-  "version": "0.4.66-6",
+  "version": "0.4.66-7",
   "devDependencies": {
     "@types/bun": "latest",
     "prettier": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wasm:postbuild": "node build.js",
     "build": "npm run wasm:build && npm run wasm:postbuild"
   },
-  "version": "0.4.66-5",
+  "version": "0.4.66-6",
   "devDependencies": {
     "@types/bun": "latest",
     "prettier": "^3.3.3"

--- a/src/circuit/circom.rs
+++ b/src/circuit/circom.rs
@@ -316,7 +316,7 @@ pub async fn generate_claim_input(
     account_code: &str,
 ) -> Result<String> {
     // Convert the email address to a padded format
-    let padded_email_address = PaddedEmailAddr::from_email_addr(email_address);
+    let padded_email_address = PaddedEmailAddr::from_email_addr(email_address)?;
     // Collect the padded bytes into a vector
     let padded_email_addr_bytes = padded_email_address.padded_bytes;
 

--- a/src/circuit/circom.rs
+++ b/src/circuit/circom.rs
@@ -3,8 +3,9 @@ use js_sys::Number;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
-use zk_regex_apis::extract_substrs::{
-    extract_substr_idxes, DecomposedRegexConfig, RegexPartConfig,
+use crate::regex::{
+    extract_substr_idxes,
+    DecomposedRegexConfig, RegexPart,
 };
 use zk_regex_compiler::{gen_circuit_inputs, NFAGraph, ProverInputs, ProvingFramework};
 
@@ -58,16 +59,104 @@ struct ClaimCircuitInput {
     account_code: String, // The account code as a string
 }
 
+/// Serializable wrapper for RegexPart that can be used in JSON files
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum SerializableRegexPart {
+    Pattern(String),
+    PublicPattern((String, usize)),
+}
+
+impl From<SerializableRegexPart> for RegexPart {
+    fn from(part: SerializableRegexPart) -> Self {
+        match part {
+            SerializableRegexPart::Pattern(p) => RegexPart::Pattern(p),
+            SerializableRegexPart::PublicPattern((p, max)) => RegexPart::PublicPattern((p, max)),
+        }
+    }
+}
+
+impl From<RegexPart> for SerializableRegexPart {
+    fn from(part: RegexPart) -> Self {
+        match part {
+            RegexPart::Pattern(p) => SerializableRegexPart::Pattern(p),
+            RegexPart::PublicPattern((p, max)) => SerializableRegexPart::PublicPattern((p, max)),
+        }
+    }
+}
+
+impl From<&RegexPart> for SerializableRegexPart {
+    fn from(part: &RegexPart) -> Self {
+        match part {
+            RegexPart::Pattern(p) => SerializableRegexPart::Pattern(p.clone()),
+            RegexPart::PublicPattern((p, max)) => SerializableRegexPart::PublicPattern((p.clone(), *max)),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecomposedRegex {
-    pub parts: Vec<RegexPartConfig>, // The parts of the regex configuration
+    #[serde(with = "regex_parts_serde")]
+    pub parts: Vec<RegexPart>,       // The parts of the regex configuration (using new RegexPart enum)
     pub name: String,                // The name of the decomposed regex
     pub max_match_length: usize,     // The maximum length of the regex match
     pub max_haystack_length: usize,  // The maximum length of the haystack
     pub haystack_location: String, // The location where the regex is applied (e.g., header or body)
     pub regex_graph_json: String,
     pub proving_framework: ProvingFramework,
+}
+
+impl std::fmt::Debug for DecomposedRegex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DecomposedRegex")
+            .field("name", &self.name)
+            .field("max_match_length", &self.max_match_length)
+            .field("max_haystack_length", &self.max_haystack_length)
+            .field("haystack_location", &self.haystack_location)
+            .field("regex_graph_json", &"<json>")
+            .field("proving_framework", &self.proving_framework)
+            .finish()
+    }
+}
+
+impl Clone for DecomposedRegex {
+    fn clone(&self) -> Self {
+        DecomposedRegex {
+            parts: self.parts.iter().map(|p| match p {
+                RegexPart::Pattern(s) => RegexPart::Pattern(s.clone()),
+                RegexPart::PublicPattern((s, n)) => RegexPart::PublicPattern((s.clone(), *n)),
+            }).collect(),
+            name: self.name.clone(),
+            max_match_length: self.max_match_length,
+            max_haystack_length: self.max_haystack_length,
+            haystack_location: self.haystack_location.clone(),
+            regex_graph_json: self.regex_graph_json.clone(),
+            proving_framework: self.proving_framework.clone(),
+        }
+    }
+}
+
+// Custom serde module for Vec<RegexPart>
+mod regex_parts_serde {
+    use super::*;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(parts: &Vec<RegexPart>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let serializable: Vec<SerializableRegexPart> = parts.iter().map(|p| p.clone().into()).collect();
+        serializable.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<RegexPart>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let serializable: Vec<SerializableRegexPart> = Vec::deserialize(deserializer)?;
+        Ok(serializable.into_iter().map(Into::into).collect())
+    }
 }
 
 /// Asynchronously generates the circuit input for an email.

--- a/src/circuit/circom.rs
+++ b/src/circuit/circom.rs
@@ -1,10 +1,8 @@
 use anyhow::Result;
-use js_sys::Number;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
 use crate::regex::{
-    extract_substr_idxes,
     DecomposedRegexConfig, RegexPart,
 };
 use zk_regex_compiler::{gen_circuit_inputs, NFAGraph, ProverInputs, ProvingFramework};
@@ -132,7 +130,7 @@ impl Clone for DecomposedRegex {
             max_haystack_length: self.max_haystack_length,
             haystack_location: self.haystack_location.clone(),
             regex_graph_json: self.regex_graph_json.clone(),
-            proving_framework: self.proving_framework.clone(),
+            proving_framework: self.proving_framework,
         }
     }
 }
@@ -142,11 +140,11 @@ mod regex_parts_serde {
     use super::*;
     use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S>(parts: &Vec<RegexPart>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(parts: &[RegexPart], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let serializable: Vec<SerializableRegexPart> = parts.iter().map(|p| p.clone().into()).collect();
+        let serializable: Vec<SerializableRegexPart> = parts.iter().map(|p| p.into()).collect();
         serializable.serialize(serializer)
     }
 

--- a/src/circuit/circom.rs
+++ b/src/circuit/circom.rs
@@ -1,10 +1,8 @@
+use crate::regex::{DecomposedRegexConfig, RegexPart};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::VecDeque;
-use crate::regex::{
-    DecomposedRegexConfig, RegexPart,
-};
 use zk_regex_compiler::{gen_circuit_inputs, NFAGraph, ProverInputs, ProvingFramework};
 
 use crate::{
@@ -87,7 +85,9 @@ impl From<&RegexPart> for SerializableRegexPart {
     fn from(part: &RegexPart) -> Self {
         match part {
             RegexPart::Pattern(p) => SerializableRegexPart::Pattern(p.clone()),
-            RegexPart::PublicPattern((p, max)) => SerializableRegexPart::PublicPattern((p.clone(), *max)),
+            RegexPart::PublicPattern((p, max)) => {
+                SerializableRegexPart::PublicPattern((p.clone(), *max))
+            }
         }
     }
 }
@@ -96,10 +96,10 @@ impl From<&RegexPart> for SerializableRegexPart {
 #[serde(rename_all = "camelCase")]
 pub struct DecomposedRegex {
     #[serde(with = "regex_parts_serde")]
-    pub parts: Vec<RegexPart>,       // The parts of the regex configuration (using new RegexPart enum)
-    pub name: String,                // The name of the decomposed regex
-    pub max_match_length: usize,     // The maximum length of the regex match
-    pub max_haystack_length: usize,  // The maximum length of the haystack
+    pub parts: Vec<RegexPart>, // The parts of the regex configuration (using new RegexPart enum)
+    pub name: String,               // The name of the decomposed regex
+    pub max_match_length: usize,    // The maximum length of the regex match
+    pub max_haystack_length: usize, // The maximum length of the haystack
     pub haystack_location: String, // The location where the regex is applied (e.g., header or body)
     pub regex_graph_json: String,
     pub proving_framework: ProvingFramework,
@@ -121,10 +121,14 @@ impl std::fmt::Debug for DecomposedRegex {
 impl Clone for DecomposedRegex {
     fn clone(&self) -> Self {
         DecomposedRegex {
-            parts: self.parts.iter().map(|p| match p {
-                RegexPart::Pattern(s) => RegexPart::Pattern(s.clone()),
-                RegexPart::PublicPattern((s, n)) => RegexPart::PublicPattern((s.clone(), *n)),
-            }).collect(),
+            parts: self
+                .parts
+                .iter()
+                .map(|p| match p {
+                    RegexPart::Pattern(s) => RegexPart::Pattern(s.clone()),
+                    RegexPart::PublicPattern((s, n)) => RegexPart::PublicPattern((s.clone(), *n)),
+                })
+                .collect(),
             name: self.name.clone(),
             max_match_length: self.max_match_length,
             max_haystack_length: self.max_haystack_length,

--- a/src/cryptos.rs
+++ b/src/cryptos.rs
@@ -100,14 +100,31 @@ impl PaddedEmailAddr {
     ///
     /// # Returns
     ///
-    /// A new instance of `PaddedEmailAddr`.
-    pub fn from_email_addr(email_addr: &str) -> Self {
+    /// A `Result` containing a new instance of `PaddedEmailAddr` or an error if the email address
+    /// exceeds the maximum length of 256 bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the email address length exceeds `MAX_EMAIL_ADDR_BYTES` (256 bytes).
+    /// This validation prevents potential security issues where different email addresses could
+    /// produce identical padded representations due to silent truncation.
+    pub fn from_email_addr(email_addr: &str) -> Result<Self> {
         let email_addr_len = email_addr.as_bytes().len();
+
+        // Validate that the email address does not exceed the maximum allowed length
+        if email_addr_len > MAX_EMAIL_ADDR_BYTES {
+            return Err(anyhow::anyhow!(
+                "Email address length ({} bytes) exceeds maximum allowed length ({} bytes)",
+                email_addr_len,
+                MAX_EMAIL_ADDR_BYTES
+            ));
+        }
+
         let padded_bytes = pad_string(email_addr, MAX_EMAIL_ADDR_BYTES);
-        Self {
+        Ok(Self {
             padded_bytes,
             email_addr_len,
-        }
+        })
     }
 
     /// Converts the padded email address into a vector of field elements.
@@ -588,6 +605,104 @@ mod tests {
         assert_eq!(field_to_hex(&hash_field), expected_hash);
     }
 
+    #[test]
+    fn test_padded_email_addr_valid() {
+        // Test with a valid email address
+        let email = "test@example.com";
+        let result = PaddedEmailAddr::from_email_addr(email);
+        assert!(result.is_ok());
+
+        let padded = result.unwrap();
+        assert_eq!(padded.email_addr_len, email.len());
+        assert_eq!(padded.padded_bytes.len(), MAX_EMAIL_ADDR_BYTES);
+        assert_eq!(&padded.padded_bytes[..email.len()], email.as_bytes());
+
+        // Verify padding is zeros
+        for i in email.len()..MAX_EMAIL_ADDR_BYTES {
+            assert_eq!(padded.padded_bytes[i], 0);
+        }
+    }
+
+    #[test]
+    fn test_padded_email_addr_exactly_256_bytes() {
+        // Test with an email address that is exactly 256 bytes (boundary case)
+        let email = "a".repeat(256);
+        let result = PaddedEmailAddr::from_email_addr(&email);
+        assert!(result.is_ok());
+
+        let padded = result.unwrap();
+        assert_eq!(padded.email_addr_len, 256);
+        assert_eq!(padded.padded_bytes.len(), MAX_EMAIL_ADDR_BYTES);
+    }
+
+    #[test]
+    fn test_padded_email_addr_exceeds_max_length() {
+        // Test with an email address that exceeds 256 bytes
+        let email = "a".repeat(257);
+        let result = PaddedEmailAddr::from_email_addr(&email);
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        let error_msg = error.to_string();
+        assert!(
+            error_msg.contains("exceeds maximum allowed length"),
+            "Expected error message about exceeding max length, got: {}",
+            error_msg
+        );
+    }
+
+    #[test]
+    fn test_padded_email_addr_collision_prevention() {
+        // Test that two different emails exceeding 256 bytes would have been rejected
+        // This demonstrates the security fix preventing collision attacks
+        let email1 = format!("{}@example.com", "a".repeat(250));
+        let email2 = format!("{}@different.com", "a".repeat(250));
+
+        // Both should be rejected since they exceed 256 bytes
+        assert!(PaddedEmailAddr::from_email_addr(&email1).is_err());
+        assert!(PaddedEmailAddr::from_email_addr(&email2).is_err());
+    }
+
+    #[test]
+    fn test_padded_email_addr_long_but_valid() {
+        // Test with a long but valid email (under 256 bytes)
+        let local_part = "a".repeat(200);
+        let email = format!("{}@example.com", local_part);
+        assert!(email.len() < MAX_EMAIL_ADDR_BYTES);
+
+        let result = PaddedEmailAddr::from_email_addr(&email);
+        assert!(result.is_ok());
+
+        let padded = result.unwrap();
+        assert_eq!(padded.email_addr_len, email.len());
+    }
+
+    #[test]
+    fn test_calculate_account_salt_with_valid_email() {
+        // Test calculate_account_salt with valid email
+        let email = "test@example.com";
+        // Use a valid 32-byte hex string (64 hex chars) for field element
+        let account_code = "0x0000000000000000000000000000000000000000000000000000000000000001";
+        let result = calculate_account_salt(email, account_code);
+        assert!(
+            result.is_ok(),
+            "Expected Ok, got Err: {:?}",
+            result.unwrap_err()
+        );
+    }
+
+    #[test]
+    fn test_calculate_account_salt_with_invalid_email() {
+        // Test calculate_account_salt with email exceeding max length
+        let email = "a".repeat(300);
+        let account_code = "0x1234567890abcdef";
+        let result = calculate_account_salt(&email, account_code);
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        assert!(error.to_string().contains("exceeds maximum allowed length"));
+    }
+
     #[tokio::test]
     async fn test_fetch_public_key() -> Result<()> {
         if std::env::var("CI").is_ok() {
@@ -688,24 +803,24 @@ pub fn calculate_default_hash(input: &str) -> String {
 ///
 /// # Returns
 ///
-/// A string representation of the calculated account salt.
-pub fn calculate_account_salt(email_addr: &str, account_code: &str) -> String {
-    // Pad the email address
-    let padded_email_addr = PaddedEmailAddr::from_email_addr(email_addr);
+/// A `Result` containing the string representation of the calculated account salt or an error.
+pub fn calculate_account_salt(email_addr: &str, account_code: &str) -> Result<String> {
+    // Pad the email address (now returns Result)
+    let padded_email_addr = PaddedEmailAddr::from_email_addr(email_addr)?;
 
     // Convert account code to field element
     let account_code = if account_code.starts_with("0x") {
-        hex_to_field(account_code).unwrap()
+        hex_to_field(account_code)?
     } else {
-        hex_to_field(&format!("0x{}", account_code)).unwrap()
+        hex_to_field(&format!("0x{}", account_code))?
     };
     let account_code = AccountCode::from(account_code);
 
     // Generate account salt
-    let account_salt = AccountSalt::new(&padded_email_addr, account_code).unwrap();
+    let account_salt = AccountSalt::new(&padded_email_addr, account_code)?;
 
     // Convert account salt to hexadecimal representation
-    field_to_hex(&account_salt.0)
+    Ok(field_to_hex(&account_salt.0))
 }
 
 /// Fetches the public key from DNS records using the DKIM signature in the email headers.

--- a/src/cryptos.rs
+++ b/src/cryptos.rs
@@ -1,5 +1,6 @@
 //! Cryptographic functions.
 
+use crate::regex::pad_string;
 use crate::EmailHeaders;
 use crate::{field_to_hex, hex_to_field};
 use anyhow::Result;
@@ -25,7 +26,6 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
 };
-use crate::regex::pad_string;
 
 use crate::{
     converters::{

--- a/src/cryptos.rs
+++ b/src/cryptos.rs
@@ -25,7 +25,7 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
 };
-use zk_regex_apis::padding::pad_string;
+use crate::regex::pad_string;
 
 use crate::{
     converters::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,8 @@ pub use proof::*;
 
 // Re-export commonly used items from regex module
 pub use regex::{
-    extract_substr_idxes, extract_substr,
-    extract_email_addr_idxes, extract_from_addr_idxes, extract_to_addr_idxes,
-    extract_subject_all_idxes, extract_body_hash_idxes, extract_timestamp_idxes,
-    extract_message_id_idxes, extract_email_domain_idxes,
-    pad_string, pad_bytes,
-    DecomposedRegexConfig, RegexPart, NFAGraph,
-    ExtractionError, ExtractionResult,
+    extract_body_hash_idxes, extract_email_addr_idxes, extract_email_domain_idxes,
+    extract_from_addr_idxes, extract_message_id_idxes, extract_subject_all_idxes, extract_substr,
+    extract_substr_idxes, extract_timestamp_idxes, extract_to_addr_idxes, pad_bytes, pad_string,
+    DecomposedRegexConfig, ExtractionError, ExtractionResult, NFAGraph, RegexPart,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod logger;
 pub mod parse_email;
 pub mod proof;
 pub mod regex;
+
+#[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
 pub use circuit::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cryptos;
 pub mod logger;
 pub mod parse_email;
 pub mod proof;
+pub mod regex;
 pub mod wasm;
 
 pub use circuit::*;
@@ -17,5 +18,13 @@ pub use logger::*;
 pub use parse_email::*;
 pub use proof::*;
 
-pub use zk_regex_apis::extract_substrs::*;
-pub use zk_regex_apis::padding::*;
+// Re-export commonly used items from regex module
+pub use regex::{
+    extract_substr_idxes, extract_substr,
+    extract_email_addr_idxes, extract_from_addr_idxes, extract_to_addr_idxes,
+    extract_subject_all_idxes, extract_body_hash_idxes, extract_timestamp_idxes,
+    extract_message_id_idxes, extract_email_domain_idxes,
+    pad_string, pad_bytes,
+    DecomposedRegexConfig, RegexPart, NFAGraph,
+    ExtractionError, ExtractionResult,
+};

--- a/src/parse_email.rs
+++ b/src/parse_email.rs
@@ -3,17 +3,17 @@
 use std::collections::HashMap;
 
 use crate::cryptos::fetch_public_key_and_verify;
+use crate::regex::{
+    extract_body_hash_idxes, extract_email_addr_idxes, extract_email_domain_idxes,
+    extract_from_addr_idxes, extract_message_id_idxes, extract_subject_all_idxes,
+    extract_substr_idxes, extract_timestamp_idxes, extract_to_addr_idxes,
+};
 use anyhow::Result;
 use cfdkim::canonicalize_signed_email;
 use hex;
 use itertools::Itertools;
 use mailparse::{parse_mail, ParsedMail};
 use serde::{Deserialize, Serialize};
-use crate::regex::{
-    extract_body_hash_idxes, extract_email_addr_idxes, extract_email_domain_idxes,
-    extract_from_addr_idxes, extract_message_id_idxes, extract_subject_all_idxes,
-    extract_substr_idxes, extract_timestamp_idxes, extract_to_addr_idxes,
-};
 
 /// `ParsedEmail` holds the canonicalized parts of an email along with its signature and public key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -206,7 +206,8 @@ impl ParsedEmail {
     pub fn get_invitation_code(&self, ignore_body_hash_check: bool) -> Result<String> {
         let regex_config = serde_json::from_str(include_str!("../regexes/invitation_code.json"))?;
         if ignore_body_hash_check {
-            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
+            let idxes =
+                extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
             let str = self.canonicalized_header[idxes.0..idxes.1].to_string();
             Ok(str)
         } else {
@@ -223,7 +224,8 @@ impl ParsedEmail {
     ) -> Result<(usize, usize)> {
         let regex_config = serde_json::from_str(include_str!("../regexes/invitation_code.json"))?;
         if ignore_body_hash_check {
-            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
+            let idxes =
+                extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
             Ok(idxes)
         } else {
             let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, None, false)?[0];
@@ -266,13 +268,15 @@ impl ParsedEmail {
                     let str = self.canonicalized_body[idxes[0].0..idxes[0].1].to_string();
                     Ok(str.replace("=\r\n", ""))
                 }
-                Err(_) => match extract_substr_idxes(&self.cleaned_body, &regex_config, None, false) {
-                    Ok(idxes) => {
-                        let str = self.cleaned_body[idxes[0].0..idxes[0].1].to_string();
-                        Ok(str)
+                Err(_) => {
+                    match extract_substr_idxes(&self.cleaned_body, &regex_config, None, false) {
+                        Ok(idxes) => {
+                            let str = self.cleaned_body[idxes[0].0..idxes[0].1].to_string();
+                            Ok(str)
+                        }
+                        _ => Ok("".to_string()),
                     }
-                    _ => Ok("".to_string()),
-                },
+                }
             }
         }
     }

--- a/src/parse_email.rs
+++ b/src/parse_email.rs
@@ -9,7 +9,7 @@ use hex;
 use itertools::Itertools;
 use mailparse::{parse_mail, ParsedMail};
 use serde::{Deserialize, Serialize};
-use zk_regex_apis::extract_substrs::{
+use crate::regex::{
     extract_body_hash_idxes, extract_email_addr_idxes, extract_email_domain_idxes,
     extract_from_addr_idxes, extract_message_id_idxes, extract_subject_all_idxes,
     extract_substr_idxes, extract_timestamp_idxes, extract_to_addr_idxes,
@@ -206,11 +206,11 @@ impl ParsedEmail {
     pub fn get_invitation_code(&self, ignore_body_hash_check: bool) -> Result<String> {
         let regex_config = serde_json::from_str(include_str!("../regexes/invitation_code.json"))?;
         if ignore_body_hash_check {
-            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, false)?[0];
+            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
             let str = self.canonicalized_header[idxes.0..idxes.1].to_string();
             Ok(str)
         } else {
-            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, false)?[0];
+            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, None, false)?[0];
             let str = self.cleaned_body[idxes.0..idxes.1].to_string();
             Ok(str)
         }
@@ -223,10 +223,10 @@ impl ParsedEmail {
     ) -> Result<(usize, usize)> {
         let regex_config = serde_json::from_str(include_str!("../regexes/invitation_code.json"))?;
         if ignore_body_hash_check {
-            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, false)?[0];
+            let idxes = extract_substr_idxes(&self.canonicalized_header, &regex_config, None, false)?[0];
             Ok(idxes)
         } else {
-            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, false)?[0];
+            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, None, false)?[0];
             Ok(idxes)
         }
     }
@@ -261,12 +261,12 @@ impl ParsedEmail {
         if ignore_body_hash_check {
             Ok("".to_string())
         } else {
-            match extract_substr_idxes(&self.canonicalized_body, &regex_config, false) {
+            match extract_substr_idxes(&self.canonicalized_body, &regex_config, None, false) {
                 Ok(idxes) => {
                     let str = self.canonicalized_body[idxes[0].0..idxes[0].1].to_string();
                     Ok(str.replace("=\r\n", ""))
                 }
-                Err(_) => match extract_substr_idxes(&self.cleaned_body, &regex_config, false) {
+                Err(_) => match extract_substr_idxes(&self.cleaned_body, &regex_config, None, false) {
                     Ok(idxes) => {
                         let str = self.cleaned_body[idxes[0].0..idxes[0].1].to_string();
                         Ok(str)
@@ -283,7 +283,7 @@ impl ParsedEmail {
         if ignore_body_hash_check {
             Ok((0, 0))
         } else {
-            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, false)?[0];
+            let idxes = extract_substr_idxes(&self.cleaned_body, &regex_config, None, false)?[0];
             Ok(idxes)
         }
     }

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -1,0 +1,303 @@
+use fancy_regex::Regex;
+use crate::regex::types::{DecomposedRegexConfig, RegexPart, NFAGraph, ExtractionError, ExtractionResult};
+
+/// Extracts substring indices matching a decomposed regex pattern
+///
+/// This function supports two modes:
+///
+/// 1. **With NFAGraph** (`nfa_graph = Some(&nfa)`):
+///    - Uses capture groups from the compiler's NFAGraph
+///    - Ensures extraction aligns with circuit witness generation
+///    - Recommended when used in circuit contexts
+///
+/// 2. **Without NFAGraph** (`nfa_graph = None`):
+///    - Creates capture groups based on PublicPattern parts
+///    - Works standalone without compiler dependency
+///    - Suitable for simple extraction use cases
+///
+/// # Arguments
+/// * `input` - The input string to search
+/// * `config` - The decomposed regex configuration
+/// * `nfa_graph` - Optional NFAGraph from compiler (use when available)
+/// * `reveal_private` - Whether to include private (non-public) pattern matches
+///
+/// # Returns
+/// A vector of (start, end) tuples for each match
+///
+/// # Examples
+///
+/// ```rust
+/// // With NFAGraph (circuit context)
+/// let nfa = NFAGraph::from_json(&regex_graph_json)?;
+/// let indices = extract_substr_idxes(input, &config, Some(&nfa), false)?;
+///
+/// // Without NFAGraph (standalone)
+/// let indices = extract_substr_idxes(input, &config, None, false)?;
+/// ```
+pub fn extract_substr_idxes(
+    input: &str,
+    config: &DecomposedRegexConfig,
+    nfa_graph: Option<&NFAGraph>,
+    reveal_private: bool,
+) -> ExtractionResult<Vec<(usize, usize)>> {
+    if let Some(nfa) = nfa_graph {
+        // Path 1: Use NFAGraph's capture groups
+        extract_with_nfa(input, config, nfa, reveal_private)
+    } else {
+        // Path 2: Create our own capture groups
+        extract_without_nfa(input, config, reveal_private)
+    }
+}
+
+/// Extract using NFAGraph's capture group structure
+fn extract_with_nfa(
+    input: &str,
+    config: &DecomposedRegexConfig,
+    nfa: &NFAGraph,
+    reveal_private: bool,
+) -> ExtractionResult<Vec<(usize, usize)>> {
+    // Parse capture groups from NFAGraph
+    let capture_group_count = nfa.num_capture_groups;
+
+    // Compose pattern maintaining NFA's structure
+    // The NFAGraph already knows which parts are capture groups
+    let pattern = compose_pattern_for_nfa(config, nfa)?;
+
+    // Compile and execute regex
+    let regex = Regex::new(&pattern)
+        .map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
+
+    let mut results = Vec::new();
+
+    for captures in regex.captures_iter(input) {
+        let captures = captures
+            .map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
+
+        if reveal_private {
+            // Return full match
+            if let Some(m) = captures.get(0) {
+                results.push((m.start(), m.end()));
+            }
+        } else {
+            // Return only captures corresponding to PublicPattern parts
+            // Capture groups are numbered 1..=capture_group_count
+            for group_id in 1..=capture_group_count {
+                if let Some(m) = captures.get(group_id) {
+                    results.push((m.start(), m.end()));
+                }
+            }
+        }
+    }
+
+    if results.is_empty() {
+        Err(ExtractionError::NoMatch)
+    } else {
+        Ok(results)
+    }
+}
+
+/// Extract creating own capture groups from config
+fn extract_without_nfa(
+    input: &str,
+    config: &DecomposedRegexConfig,
+    reveal_private: bool,
+) -> ExtractionResult<Vec<(usize, usize)>> {
+    // Compose pattern with capture groups around PublicPattern parts
+    let (pattern, public_group_indices) = compose_pattern_standalone(config)?;
+
+    // Compile and execute regex
+    let regex = Regex::new(&pattern)
+        .map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
+
+    let mut results = Vec::new();
+
+    for captures in regex.captures_iter(input) {
+        let captures = captures
+            .map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
+
+        if reveal_private {
+            // Return full match
+            if let Some(m) = captures.get(0) {
+                results.push((m.start(), m.end()));
+            }
+        } else {
+            // Return only public capture groups
+            for group_idx in &public_group_indices {
+                if let Some(m) = captures.get(*group_idx) {
+                    results.push((m.start(), m.end()));
+                }
+            }
+        }
+    }
+
+    if results.is_empty() {
+        Err(ExtractionError::NoMatch)
+    } else {
+        Ok(results)
+    }
+}
+
+/// Compose pattern for NFAGraph-based extraction
+/// Trust that the NFAGraph knows the correct capture group structure
+fn compose_pattern_for_nfa(
+    config: &DecomposedRegexConfig,
+    nfa: &NFAGraph,
+) -> ExtractionResult<String> {
+    let mut pattern = String::new();
+    let mut public_count = 0;
+
+    for part in &config.parts {
+        let part_pattern = match part {
+            RegexPart::Pattern(p) => {
+                // Wrap in non-capturing group
+                format!("(?:{})", p)
+            },
+            RegexPart::PublicPattern((p, _max_bytes)) => {
+                public_count += 1;
+                // Wrap in capturing group
+                format!("({})", p)
+            }
+        };
+        pattern.push_str(&part_pattern);
+    }
+
+    // Verify we got the expected number of public parts
+    if public_count != nfa.num_capture_groups {
+        return Err(ExtractionError::InvalidConfig(format!(
+            "Config has {} public parts but NFAGraph has {} capture groups",
+            public_count, nfa.num_capture_groups
+        )));
+    }
+
+    if pattern.is_empty() {
+        return Err(ExtractionError::InvalidConfig("Empty pattern".to_string()));
+    }
+
+    Ok(pattern)
+}
+
+/// Compose pattern for standalone extraction
+/// Create capture groups around PublicPattern parts
+fn compose_pattern_standalone(
+    config: &DecomposedRegexConfig,
+) -> ExtractionResult<(String, Vec<usize>)> {
+    let mut pattern = String::new();
+    let mut public_group_indices = Vec::new();
+    let mut current_group = 1; // Group 0 is always the full match
+
+    for part in &config.parts {
+        let part_pattern = match part {
+            RegexPart::Pattern(p) => {
+                // Wrap in non-capturing group
+                format!("(?:{})", p)
+            },
+            RegexPart::PublicPattern((p, _max_bytes)) => {
+                // Wrap in capturing group
+                public_group_indices.push(current_group);
+                current_group += 1;
+                format!("({})", p)
+            }
+        };
+        pattern.push_str(&part_pattern);
+    }
+
+    if pattern.is_empty() {
+        return Err(ExtractionError::InvalidConfig("Empty pattern".to_string()));
+    }
+
+    Ok((pattern, public_group_indices))
+}
+
+/// Extracts actual substrings matching a decomposed regex pattern
+///
+/// # Arguments
+/// * `input` - The input string to search
+/// * `config` - The decomposed regex configuration
+/// * `nfa_graph` - Optional NFAGraph from compiler
+/// * `reveal_private` - Whether to include private (non-public) pattern matches
+///
+/// # Returns
+/// A vector of matched strings
+pub fn extract_substr(
+    input: &str,
+    config: &DecomposedRegexConfig,
+    nfa_graph: Option<&NFAGraph>,
+    reveal_private: bool,
+) -> ExtractionResult<Vec<String>> {
+    let indices = extract_substr_idxes(input, config, nfa_graph, reveal_private)?;
+
+    Ok(indices
+        .into_iter()
+        .map(|(start, end)| input[start..end].to_string())
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_without_nfa() {
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("prefix:".to_string()),
+                RegexPart::PublicPattern(("\\w+".to_string(), 20)),
+            ],
+        };
+
+        let input = "prefix:hello world prefix:test";
+        let result = extract_substr_idxes(input, &config, None, false).unwrap();
+
+        // Should find "hello" and "test" (public parts only)
+        assert_eq!(result.len(), 2);
+        assert_eq!(&input[result[0].0..result[0].1], "hello");
+        assert_eq!(&input[result[1].0..result[1].1], "test");
+    }
+
+    #[test]
+    fn test_extract_substr() {
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("from:".to_string()),
+                RegexPart::PublicPattern(("[a-z]+@[a-z]+\\.com".to_string(), 50)),
+            ],
+        };
+
+        let input = "from:alice@example.com";
+        let result = extract_substr(input, &config, None, false).unwrap();
+
+        assert_eq!(result, vec!["alice@example.com"]);
+    }
+
+    #[test]
+    fn test_no_match_returns_error() {
+        let config = DecomposedRegexConfig {
+            parts: vec![RegexPart::Pattern("notfound".to_string())],
+        };
+
+        let input = "this does not match";
+        let result = extract_substr_idxes(input, &config, None, false);
+
+        assert!(matches!(result, Err(ExtractionError::NoMatch)));
+    }
+
+    #[test]
+    fn test_reveal_private_returns_full_match() {
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("prefix:".to_string()),
+                RegexPart::PublicPattern(("\\w+".to_string(), 20)),
+            ],
+        };
+
+        let input = "prefix:hello";
+
+        // reveal_private = false: only public part
+        let public_only = extract_substr_idxes(input, &config, None, false).unwrap();
+        assert_eq!(&input[public_only[0].0..public_only[0].1], "hello");
+
+        // reveal_private = true: full match
+        let full_match = extract_substr_idxes(input, &config, None, true).unwrap();
+        assert_eq!(&input[full_match[0].0..full_match[0].1], "prefix:hello");
+    }
+}

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -178,7 +178,6 @@ fn compose_pattern_for_nfa(
     for part in &config.parts {
         match part {
             RegexPart::Pattern(p) => {
-                // Wrap in non-capturing group
                 pattern.push_str(p);
             }
             RegexPart::PublicPattern((p, _max_bytes)) => {
@@ -216,13 +215,12 @@ fn compose_pattern_standalone(
     for part in &config.parts {
         match part {
             RegexPart::Pattern(p) => {
-                // Wrap in non-capturing group
                 pattern.push_str(p);
             }
             RegexPart::PublicPattern((p, _max_bytes)) => {
-                // Wrap in capturing group
                 public_group_indices.push(current_group);
                 current_group += 1;
+                // Wrap in capturing group
                 pattern.push_str(&format!("({})", p).as_str());
             }
         };

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -1,5 +1,7 @@
+use crate::regex::types::{
+    DecomposedRegexConfig, ExtractionError, ExtractionResult, NFAGraph, RegexPart,
+};
 use fancy_regex::Regex;
-use crate::regex::types::{DecomposedRegexConfig, RegexPart, NFAGraph, ExtractionError, ExtractionResult};
 
 /// Extracts substring indices matching a decomposed regex pattern
 ///
@@ -26,13 +28,42 @@ use crate::regex::types::{DecomposedRegexConfig, RegexPart, NFAGraph, Extraction
 ///
 /// # Examples
 ///
-/// ```rust
-/// // With NFAGraph (circuit context)
-/// let nfa = NFAGraph::from_json(&regex_graph_json)?;
-/// let indices = extract_substr_idxes(input, &config, Some(&nfa), false)?;
+/// Basic usage without `NFAGraph`:
+/// ```
+/// use relayer_utils::{DecomposedRegexConfig, RegexPart, extract_substr_idxes};
 ///
-/// // Without NFAGraph (standalone)
-/// let indices = extract_substr_idxes(input, &config, None, false)?;
+/// let config = DecomposedRegexConfig {
+///     parts: vec![
+///         RegexPart::Pattern("prefix:".to_string()),
+///         RegexPart::PublicPattern(("\\w+".to_string(), 20)),
+///     ],
+/// };
+///
+/// let input = "prefix:hello world prefix:test";
+/// let indices = extract_substr_idxes(input, &config, None, false).unwrap();
+///
+/// assert_eq!(&input[indices[0].0..indices[0].1], "hello");
+/// assert_eq!(&input[indices[1].0..indices[1].1], "test");
+/// ```
+///
+/// With `NFAGraph` (circuit context):
+/// ```ignore
+/// use relayer_utils::{NFAGraph, DecomposedRegexConfig, RegexPart, extract_substr_idxes};
+///
+/// // Pseudocode: obtain a valid regex graph JSON from the compiler
+/// let regex_graph_json = "...";
+/// let nfa = NFAGraph::from_json(&regex_graph_json)?;
+///
+/// let config = DecomposedRegexConfig {
+///     parts: vec![
+///         RegexPart::Pattern("prefix:".to_string()),
+///         RegexPart::PublicPattern(("\\w+".to_string(), 20)),
+///     ],
+/// };
+///
+/// let input = "prefix:hello";
+/// let indices = extract_substr_idxes(input, &config, Some(&nfa), false)?;
+/// assert_eq!(&input[indices[0].0..indices[0].1], "hello");
 /// ```
 pub fn extract_substr_idxes(
     input: &str,
@@ -64,14 +95,13 @@ fn extract_with_nfa(
     let pattern = compose_pattern_for_nfa(config, nfa)?;
 
     // Compile and execute regex
-    let regex = Regex::new(&pattern)
-        .map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
+    let regex =
+        Regex::new(&pattern).map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
 
     let mut results = Vec::new();
 
     for captures in regex.captures_iter(input) {
-        let captures = captures
-            .map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
+        let captures = captures.map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
 
         if reveal_private {
             // Return full match
@@ -106,14 +136,13 @@ fn extract_without_nfa(
     let (pattern, public_group_indices) = compose_pattern_standalone(config)?;
 
     // Compile and execute regex
-    let regex = Regex::new(&pattern)
-        .map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
+    let regex =
+        Regex::new(&pattern).map_err(|e| ExtractionError::CompilationError(e.to_string()))?;
 
     let mut results = Vec::new();
 
     for captures in regex.captures_iter(input) {
-        let captures = captures
-            .map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
+        let captures = captures.map_err(|e| ExtractionError::MatchFailed(e.to_string()))?;
 
         if reveal_private {
             // Return full match
@@ -151,7 +180,7 @@ fn compose_pattern_for_nfa(
             RegexPart::Pattern(p) => {
                 // Wrap in non-capturing group
                 pattern.push_str(p);
-            },
+            }
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_count += 1;
                 // Wrap in capturing group
@@ -189,7 +218,7 @@ fn compose_pattern_standalone(
             RegexPart::Pattern(p) => {
                 // Wrap in non-capturing group
                 pattern.push_str(p);
-            },
+            }
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 // Wrap in capturing group
                 public_group_indices.push(current_group);

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -3,30 +3,108 @@ use crate::regex::types::{
 };
 use fancy_regex::Regex;
 
-/// Converts bare capturing groups to non-capturing groups
-/// This preserves existing special groups like (?:...), (?=...), (?!...), (?<=...), etc.
+/// Converts capturing groups to non-capturing groups `(?:...)` in a regex pattern.
+/// Matches zk-regex-compiler's behavior: https://github.com/zkemail/zk-regex/blob/3d37c3110fbd1baa96d048ab658bcb47acd8731b/compiler/src/utils.rs#L37
+///
+/// This function converts:
+/// - Bare capturing groups `(...)` to `(?:...)`
+/// - Named captures `(?<name>...)` (PCRE style) to `(?:...)`
+/// - Named captures `(?P<name>...)` (Rust style) to `(?:...)`
+///
+/// This function properly handles:
+/// - Escaped parentheses like `\(` and `\)` (preserved as-is)
+/// - Parentheses within character classes like `[()]` (preserved as-is)
+/// - Special groups like `(?:...)`, `(?=...)`, `(?!...)`, etc. (preserved as-is)
+///
+/// # Arguments
+///
+/// * `pattern` - The regex pattern string to process
+///
+/// # Returns
+///
+/// A new string with all capturing groups converted to non-capturing groups
+///
+/// # Examples
+///
+/// ```text
+/// convert_bare_groups_to_non_capturing("(a|b)")         → "(?:a|b)"
+/// convert_bare_groups_to_non_capturing("(?<name>abc)")  → "(?:abc)"
+/// convert_bare_groups_to_non_capturing("(?P<name>abc)") → "(?:abc)"
+/// convert_bare_groups_to_non_capturing("(?:a|b)")       → "(?:a|b)" // unchanged
+/// convert_bare_groups_to_non_capturing(r"\(a\)")        → r"\(a\)"  // escaped parens preserved
+/// convert_bare_groups_to_non_capturing("[()]")          → "[()]"    // char class preserved
+/// ```
 fn convert_bare_groups_to_non_capturing(pattern: &str) -> String {
-    let mut result = String::new();
-    let mut chars = pattern.chars().peekable();
+    let mut result = String::with_capacity(pattern.len() + pattern.len() / 4);
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut i = 0;
+    let mut in_char_class = false;
+    let mut escaped = false;
 
-    while let Some(ch) = chars.next() {
-        if ch == '(' {
-            // Check if this is already a special group
-            if let Some(&next) = chars.peek() {
-                if next == '?' {
-                    // This is already a special group like (?:...), keep it as-is
+    while i < chars.len() {
+        let ch = chars[i];
+
+        if escaped {
+            // Previous char was backslash, this char is escaped
+            result.push(ch);
+            escaped = false;
+        } else if ch == '\\' {
+            // Start escape sequence
+            result.push(ch);
+            escaped = true;
+        } else if ch == '[' && !in_char_class {
+            // Entering character class
+            result.push(ch);
+            in_char_class = true;
+        } else if ch == ']' && in_char_class {
+            // Exiting character class
+            result.push(ch);
+            in_char_class = false;
+        } else if ch == '(' && !in_char_class {
+            // Check if this is a capturing group that needs conversion
+            if i + 1 >= chars.len() || chars[i + 1] != '?' {
+                // Bare capturing group: (...)
+                result.push_str("(?:");
+            } else if i + 2 < chars.len() && chars[i + 2] == '<' {
+                // Could be: (?<=...) positive lookbehind, or (?<!...) negative lookbehind, or (?<name>...) PCRE named capture
+                if i + 3 < chars.len() && (chars[i + 3] == '=' || chars[i + 3] == '!') {
+                    // Lookbehind assertion: (?<=...) or (?<!...)
+                    // These are special groups, preserve as-is
                     result.push(ch);
                 } else {
-                    // This is a bare capturing group, convert it
+                    // PCRE named capture: (?<name>...)
+                    // Convert to non-capturing and skip the name
                     result.push_str("(?:");
+                    i += 2; // Skip '?' and '<'
+                    // Skip until we find the closing '>'
+                    while i + 1 < chars.len() && chars[i + 1] != '>' {
+                        i += 1;
+                    }
+                    if i + 1 < chars.len() && chars[i + 1] == '>' {
+                        i += 1; // Skip the '>'
+                    }
+                }
+            } else if i + 3 < chars.len() && chars[i + 2] == 'P' && chars[i + 3] == '<' {
+                // Rust named capture: (?P<name>...)
+                // Convert to non-capturing and skip the name
+                result.push_str("(?:");
+                i += 3; // Skip '?', 'P', and '<'
+                // Skip until we find the closing '>'
+                while i + 1 < chars.len() && chars[i + 1] != '>' {
+                    i += 1;
+                }
+                if i + 1 < chars.len() && chars[i + 1] == '>' {
+                    i += 1; // Skip the '>'
                 }
             } else {
-                // Parenthesis at end of string (shouldn't happen in valid regex)
+                // Other special group like (?:...), (?=...), etc.
                 result.push(ch);
             }
         } else {
             result.push(ch);
         }
+
+        i += 1;
     }
 
     result
@@ -220,7 +298,8 @@ fn compose_pattern_for_nfa(
     for part in &config.parts {
         match part {
             RegexPart::Pattern(p) => {
-                pattern.push_str(p);
+                let adjusted_pattern = convert_bare_groups_to_non_capturing(p);
+                pattern.push_str(&adjusted_pattern);
             }
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_count += 1;
@@ -260,7 +339,8 @@ fn compose_pattern_standalone(
     for part in &config.parts {
         match part {
             RegexPart::Pattern(p) => {
-                pattern.push_str(p);
+                let adjusted_pattern = convert_bare_groups_to_non_capturing(p);
+                pattern.push_str(&adjusted_pattern);
             }
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_group_indices.push(current_group);
@@ -429,5 +509,34 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(&input[result[0].0..result[0].1], "hello-123");
+    }
+
+    #[test]
+    fn test_extract_substr_subject_all_patterns() {
+        let omit_non_capture_groups = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("(\r\n|^)subject:".to_string()),
+                RegexPart::PublicPattern(("[^\r\n]+".to_string(), 64)),
+                RegexPart::Pattern("\r\n".to_string()),
+            ],
+        };
+
+        let explicit_non_capture_groups = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("(?:\r\n|^)subject:".to_string()),
+                RegexPart::PublicPattern(("([^\r\n]+)".to_string(), 64)),
+                RegexPart::Pattern("\r\n".to_string()),
+            ],
+        };
+
+        let input = "subject:hello world\r\n";
+
+        let expected_output = "hello world";
+        
+        let result_omit_capture_groups = extract_substr(input, &omit_non_capture_groups, None, false).unwrap();
+        let result_explicit_capture_groups = extract_substr(input, &explicit_non_capture_groups, None, false).unwrap();
+        
+        assert_eq!(result_omit_capture_groups[0], expected_output);
+        assert_eq!(result_explicit_capture_groups[0], expected_output);
     }
 }

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -3,6 +3,35 @@ use crate::regex::types::{
 };
 use fancy_regex::Regex;
 
+/// Converts bare capturing groups to non-capturing groups
+/// This preserves existing special groups like (?:...), (?=...), (?!...), (?<=...), etc.
+fn convert_bare_groups_to_non_capturing(pattern: &str) -> String {
+    let mut result = String::new();
+    let mut chars = pattern.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '(' {
+            // Check if this is already a special group
+            if let Some(&next) = chars.peek() {
+                if next == '?' {
+                    // This is already a special group like (?:...), keep it as-is
+                    result.push(ch);
+                } else {
+                    // This is a bare capturing group, convert it
+                    result.push_str("(?:");
+                }
+            } else {
+                // Parenthesis at end of string (shouldn't happen in valid regex)
+                result.push(ch);
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
 /// Extracts substring indices matching a decomposed regex pattern
 ///
 /// This function supports two modes:
@@ -16,6 +45,19 @@ use fancy_regex::Regex;
 ///    - Creates capture groups based on PublicPattern parts
 ///    - Works standalone without compiler dependency
 ///    - Suitable for simple extraction use cases
+///
+/// # Capture Group Handling
+///
+/// To ensure stable and predictable capture group numbering, this function automatically
+/// converts bare capturing groups `(...)` to non-capturing groups `(?:...)` within
+/// PublicPattern parts before wrapping them in an outer capturing group. This prevents
+/// nested capture groups from interfering with the expected group indices.
+///
+/// For example:
+/// - Input pattern: `"(\w+)@(\d+)"`
+/// - Converted to: `"((?:\w+)@(?:\d+))"` (only 1 capture group)
+///
+/// Existing special groups like `(?:...)`, `(?=...)`, `(?!...)`, etc. are preserved as-is.
 ///
 /// # Arguments
 /// * `input` - The input string to search
@@ -182,8 +224,11 @@ fn compose_pattern_for_nfa(
             }
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_count += 1;
+                // Convert any bare capturing groups to non-capturing groups to prevent
+                // nested capture groups from interfering with the expected group numbering
+                let adjusted_pattern = convert_bare_groups_to_non_capturing(p);
                 // Wrap in capturing group
-                pattern.push_str(&format!("({})", p).as_str());
+                pattern.push_str(&format!("({})", adjusted_pattern).as_str());
             }
         };
     }
@@ -220,8 +265,11 @@ fn compose_pattern_standalone(
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_group_indices.push(current_group);
                 current_group += 1;
+                // Convert any bare capturing groups to non-capturing groups to prevent
+                // nested capture groups from interfering with the expected group numbering
+                let adjusted_pattern = convert_bare_groups_to_non_capturing(p);
                 // Wrap in capturing group
-                pattern.push_str(&format!("({})", p).as_str());
+                pattern.push_str(&format!("({})", adjusted_pattern).as_str());
             }
         };
     }
@@ -324,5 +372,62 @@ mod tests {
         // reveal_private = true: full match
         let full_match = extract_substr_idxes(input, &config, None, true).unwrap();
         assert_eq!(&input[full_match[0].0..full_match[0].1], "prefix:hello");
+    }
+
+    #[test]
+    fn test_nested_capturing_groups_converted() {
+        // Test that bare capturing groups inside PublicPattern are converted to non-capturing
+        // This ensures stable capture group numbering
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("data:".to_string()),
+                RegexPart::PublicPattern(("(\\w+)-(\\d+)".to_string(), 50)),
+            ],
+        };
+
+        let input = "data:hello-123";
+        let result = extract_substr_idxes(input, &config, None, false).unwrap();
+
+        // Should extract the entire public pattern match, not individual nested groups
+        assert_eq!(result.len(), 1, "Should have exactly one capture group");
+        assert_eq!(&input[result[0].0..result[0].1], "hello-123");
+    }
+
+    #[test]
+    fn test_multiple_public_patterns_with_nested_groups() {
+        // Test multiple PublicPattern parts each with nested groups
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("from:".to_string()),
+                RegexPart::PublicPattern(("(\\w+)@(\\w+)".to_string(), 50)),
+                RegexPart::Pattern(" to:".to_string()),
+                RegexPart::PublicPattern(("(\\w+)@(\\w+)".to_string(), 50)),
+            ],
+        };
+
+        let input = "from:alice@example to:bob@test";
+        let result = extract_substr_idxes(input, &config, None, false).unwrap();
+
+        // Should extract exactly two capture groups (one per PublicPattern)
+        assert_eq!(result.len(), 2, "Should have exactly two capture groups");
+        assert_eq!(&input[result[0].0..result[0].1], "alice@example");
+        assert_eq!(&input[result[1].0..result[1].1], "bob@test");
+    }
+
+    #[test]
+    fn test_already_non_capturing_groups_preserved() {
+        // Test that already non-capturing groups (?:...) work correctly
+        let config = DecomposedRegexConfig {
+            parts: vec![
+                RegexPart::Pattern("prefix:".to_string()),
+                RegexPart::PublicPattern(("(?:\\w+)-(?:\\d+)".to_string(), 50)),
+            ],
+        };
+
+        let input = "prefix:hello-123";
+        let result = extract_substr_idxes(input, &config, None, false).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(&input[result[0].0..result[0].1], "hello-123");
     }
 }

--- a/src/regex/extract.rs
+++ b/src/regex/extract.rs
@@ -147,18 +147,17 @@ fn compose_pattern_for_nfa(
     let mut public_count = 0;
 
     for part in &config.parts {
-        let part_pattern = match part {
+        match part {
             RegexPart::Pattern(p) => {
                 // Wrap in non-capturing group
-                format!("(?:{})", p)
+                pattern.push_str(p);
             },
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 public_count += 1;
                 // Wrap in capturing group
-                format!("({})", p)
+                pattern.push_str(&format!("({})", p).as_str());
             }
         };
-        pattern.push_str(&part_pattern);
     }
 
     // Verify we got the expected number of public parts
@@ -186,19 +185,18 @@ fn compose_pattern_standalone(
     let mut current_group = 1; // Group 0 is always the full match
 
     for part in &config.parts {
-        let part_pattern = match part {
+        match part {
             RegexPart::Pattern(p) => {
                 // Wrap in non-capturing group
-                format!("(?:{})", p)
+                pattern.push_str(p);
             },
             RegexPart::PublicPattern((p, _max_bytes)) => {
                 // Wrap in capturing group
                 public_group_indices.push(current_group);
                 current_group += 1;
-                format!("({})", p)
+                pattern.push_str(&format!("({})", p).as_str());
             }
         };
-        pattern.push_str(&part_pattern);
     }
 
     if pattern.is_empty() {

--- a/src/regex/mod.rs
+++ b/src/regex/mod.rs
@@ -14,19 +14,19 @@
 //! This ensures consistency when used in circuit contexts while maintaining
 //! standalone functionality.
 
-pub mod types;
 pub mod extract;
-pub mod patterns;
 pub mod padding;
+pub mod patterns;
+pub mod types;
 
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
 
 // Re-export main types and functions
-pub use types::*;
 pub use extract::*;
-pub use patterns::*;
 pub use padding::*;
+pub use patterns::*;
+pub use types::*;
 
 // Re-export NFAGraph from compiler for convenience
 pub use zk_regex_compiler::NFAGraph;

--- a/src/regex/mod.rs
+++ b/src/regex/mod.rs
@@ -1,0 +1,32 @@
+//! Runtime regex extraction utilities for email parsing
+//!
+//! This module provides runtime regex extraction functionality using
+//! DecomposedRegexConfig from zk-regex-compiler. It is separate from
+//! circuit generation and focuses on runtime text extraction.
+//!
+//! # Design: Hybrid Extraction Approach
+//!
+//! This module implements a hybrid approach for capture group handling:
+//!
+//! - **With NFAGraph**: Uses compiler's capture groups for alignment with circuits
+//! - **Without NFAGraph**: Creates own capture groups based on PublicPattern parts
+//!
+//! This ensures consistency when used in circuit contexts while maintaining
+//! standalone functionality.
+
+pub mod types;
+pub mod extract;
+pub mod patterns;
+pub mod padding;
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
+// Re-export main types and functions
+pub use types::*;
+pub use extract::*;
+pub use patterns::*;
+pub use padding::*;
+
+// Re-export NFAGraph from compiler for convenience
+pub use zk_regex_compiler::NFAGraph;

--- a/src/regex/padding.rs
+++ b/src/regex/padding.rs
@@ -1,0 +1,50 @@
+/// Pads a string to the specified size with zero bytes
+///
+/// # Arguments
+/// * `s` - The string to pad
+/// * `target_len` - The target length in bytes
+///
+/// # Returns
+/// A vector of bytes padded to target_len with zeros
+pub fn pad_string(s: &str, target_len: usize) -> Vec<u8> {
+    let mut padded = s.as_bytes().to_vec();
+    padded.resize(target_len, 0);
+    padded
+}
+
+/// Pads a byte slice to the specified size with zero bytes
+///
+/// # Arguments
+/// * `data` - The bytes to pad
+/// * `target_len` - The target length in bytes
+///
+/// # Returns
+/// A vector of bytes padded to target_len with zeros
+pub fn pad_bytes(data: &[u8], target_len: usize) -> Vec<u8> {
+    let mut padded = data.to_vec();
+    padded.resize(target_len, 0);
+    padded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pad_string() {
+        let input = "hello";
+        let padded = pad_string(input, 10);
+        assert_eq!(padded.len(), 10);
+        assert_eq!(&padded[0..5], b"hello");
+        assert_eq!(&padded[5..10], &[0u8; 5]);
+    }
+
+    #[test]
+    fn test_pad_bytes() {
+        let input = vec![1, 2, 3];
+        let padded = pad_bytes(&input, 6);
+        assert_eq!(padded.len(), 6);
+        assert_eq!(&padded[0..3], &[1, 2, 3]);
+        assert_eq!(&padded[3..6], &[0, 0, 0]);
+    }
+}

--- a/src/regex/padding.rs
+++ b/src/regex/padding.rs
@@ -6,6 +6,15 @@
 ///
 /// # Returns
 /// A vector of bytes padded to target_len with zeros
+///
+/// # Behavior
+/// - If the input string is shorter than `target_len`, it will be padded with zeros
+/// - If the input string is exactly `target_len` bytes, it will be returned as-is
+/// - If the input string exceeds `target_len`, it will be **silently truncated** to `target_len`
+///
+/// # Security Note
+/// Callers must validate input length before calling this function to prevent truncation.
+/// See `PaddedEmailAddr::from_email_addr()` for an example of proper validation.
 pub fn pad_string(s: &str, target_len: usize) -> Vec<u8> {
     let mut padded = s.as_bytes().to_vec();
     padded.resize(target_len, 0);

--- a/src/regex/patterns.rs
+++ b/src/regex/patterns.rs
@@ -1,5 +1,5 @@
-use crate::regex::types::{DecomposedRegexConfig, RegexPart, ExtractionResult, ExtractionError};
-use crate::regex::extract::{extract_substr_idxes, extract_substr};
+use crate::regex::extract::{extract_substr, extract_substr_idxes};
+use crate::regex::types::{DecomposedRegexConfig, ExtractionError, ExtractionResult, RegexPart};
 use lazy_static::lazy_static;
 
 // Pre-defined regex patterns for common email components

--- a/src/regex/patterns.rs
+++ b/src/regex/patterns.rs
@@ -1,0 +1,163 @@
+use crate::regex::types::{DecomposedRegexConfig, RegexPart, ExtractionResult, ExtractionError};
+use crate::regex::extract::{extract_substr_idxes, extract_substr};
+use lazy_static::lazy_static;
+
+// Pre-defined regex patterns for common email components
+// These are standalone patterns that don't require NFAGraph
+lazy_static! {
+    /// Pattern for extracting email addresses (user@domain.com)
+    static ref EMAIL_ADDR_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::PublicPattern((r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}".to_string(), 256)),
+        ],
+    };
+
+    /// Pattern for extracting email domain from address
+    static ref EMAIL_DOMAIN_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"[a-zA-Z0-9._%+-]+@".to_string()),
+            RegexPart::PublicPattern((r"[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}".to_string(), 256)),
+        ],
+    };
+
+    /// Pattern for extracting From header
+    static ref FROM_ADDR_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)from:.*<".to_string()),
+            RegexPart::PublicPattern((r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}".to_string(), 256)),
+            RegexPart::Pattern(r">".to_string()),
+        ],
+    };
+
+    /// Pattern for extracting To header
+    static ref TO_ADDR_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)to:.*<".to_string()),
+            RegexPart::PublicPattern((r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}".to_string(), 256)),
+            RegexPart::Pattern(r">".to_string()),
+        ],
+    };
+
+    /// Pattern for extracting Subject
+    static ref SUBJECT_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)subject:\s*".to_string()),
+            RegexPart::PublicPattern((r".+?(?=\r?\n\S|\r?\n\r?\n)".to_string(), 512)),
+        ],
+    };
+
+    /// Pattern for extracting DKIM body hash
+    static ref BODY_HASH_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)bh=".to_string()),
+            RegexPart::PublicPattern((r"[A-Za-z0-9+/=]+".to_string(), 128)),
+            RegexPart::Pattern(r";".to_string()),
+        ],
+    };
+
+    /// Pattern for extracting DKIM timestamp
+    static ref TIMESTAMP_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)t=".to_string()),
+            RegexPart::PublicPattern((r"\d+".to_string(), 32)),
+            RegexPart::Pattern(r";".to_string()),
+        ],
+    };
+
+    /// Pattern for extracting Message-ID
+    static ref MESSAGE_ID_CONFIG: DecomposedRegexConfig = DecomposedRegexConfig {
+        parts: vec![
+            RegexPart::Pattern(r"(?i)message-id:\s*<".to_string()),
+            RegexPart::PublicPattern((r"[^>]+".to_string(), 256)),
+            RegexPart::Pattern(r">".to_string()),
+        ],
+    };
+}
+
+// Convenience functions for common extractions
+// All use standalone mode (None for nfa_graph parameter)
+
+/// Extract email address indices from input
+pub fn extract_email_addr_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &EMAIL_ADDR_CONFIG, None, false)
+}
+
+/// Extract email domain indices from input
+pub fn extract_email_domain_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &EMAIL_DOMAIN_CONFIG, None, false)
+}
+
+/// Extract From header email address indices
+pub fn extract_from_addr_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &FROM_ADDR_CONFIG, None, false)
+}
+
+/// Extract To header email address indices
+pub fn extract_to_addr_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &TO_ADDR_CONFIG, None, false)
+}
+
+/// Extract Subject header indices
+pub fn extract_subject_all_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &SUBJECT_CONFIG, None, false)
+}
+
+/// Extract DKIM body hash indices
+pub fn extract_body_hash_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &BODY_HASH_CONFIG, None, false)
+}
+
+/// Extract DKIM timestamp indices
+pub fn extract_timestamp_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &TIMESTAMP_CONFIG, None, false)
+}
+
+/// Extract Message-ID indices
+pub fn extract_message_id_idxes(input: &str) -> ExtractionResult<Vec<(usize, usize)>> {
+    extract_substr_idxes(input, &MESSAGE_ID_CONFIG, None, false)
+}
+
+// String extraction variants
+
+/// Extract email addresses as strings
+pub fn extract_email_addr(input: &str) -> ExtractionResult<Vec<String>> {
+    extract_substr(input, &EMAIL_ADDR_CONFIG, None, false)
+}
+
+/// Extract From header email address as string
+pub fn extract_from_addr(input: &str) -> ExtractionResult<String> {
+    let results = extract_substr(input, &FROM_ADDR_CONFIG, None, false)?;
+    results.into_iter().next().ok_or(ExtractionError::NoMatch)
+}
+
+/// Extract DKIM body hash as string
+pub fn extract_body_hash(input: &str) -> ExtractionResult<String> {
+    let results = extract_substr(input, &BODY_HASH_CONFIG, None, false)?;
+    results.into_iter().next().ok_or(ExtractionError::NoMatch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_email_addr() {
+        let input = "Contact us at support@example.com or sales@example.com";
+        let addrs = extract_email_addr(input).unwrap();
+        assert_eq!(addrs, vec!["support@example.com", "sales@example.com"]);
+    }
+
+    #[test]
+    fn test_extract_from_addr() {
+        let input = "From: Alice <alice@example.com>\r\n";
+        let addr = extract_from_addr(input).unwrap();
+        assert_eq!(addr, "alice@example.com");
+    }
+
+    #[test]
+    fn test_extract_body_hash() {
+        let input = "dkim-signature: v=1; a=rsa-sha256; bh=abc123xyz==; d=example.com;";
+        let hash = extract_body_hash(input).unwrap();
+        assert_eq!(hash, "abc123xyz==");
+    }
+}

--- a/src/regex/types.rs
+++ b/src/regex/types.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 // Re-export new compiler types for convenience
-pub use zk_regex_compiler::{DecomposedRegexConfig, RegexPart, NFAGraph};
+pub use zk_regex_compiler::{DecomposedRegexConfig, NFAGraph, RegexPart};
 
 /// Error type for extraction operations
 #[derive(Debug, thiserror::Error)]
@@ -55,10 +55,15 @@ impl LegacyRegexPartConfig {
 impl LegacyDecomposedRegexConfig {
     /// Convert old config to new config with optional max_bytes per part
     pub fn to_new_config(&self, max_bytes_per_part: Option<Vec<usize>>) -> DecomposedRegexConfig {
-        let parts = self.parts.iter().enumerate().map(|(i, part)| {
-            let max_bytes = max_bytes_per_part.as_ref().and_then(|v| v.get(i).copied());
-            part.to_new_part(max_bytes)
-        }).collect();
+        let parts = self
+            .parts
+            .iter()
+            .enumerate()
+            .map(|(i, part)| {
+                let max_bytes = max_bytes_per_part.as_ref().and_then(|v| v.get(i).copied());
+                part.to_new_part(max_bytes)
+            })
+            .collect();
 
         DecomposedRegexConfig { parts }
     }

--- a/src/regex/types.rs
+++ b/src/regex/types.rs
@@ -1,0 +1,65 @@
+use serde::{Deserialize, Serialize};
+
+// Re-export new compiler types for convenience
+pub use zk_regex_compiler::{DecomposedRegexConfig, RegexPart, NFAGraph};
+
+/// Error type for extraction operations
+#[derive(Debug, thiserror::Error)]
+pub enum ExtractionError {
+    #[error("Invalid regex config: {0}")]
+    InvalidConfig(String),
+
+    #[error("Regex match failed: {0}")]
+    MatchFailed(String),
+
+    #[error("No matches found")]
+    NoMatch,
+
+    #[error("Regex compilation error: {0}")]
+    CompilationError(String),
+
+    #[error("NFAGraph parsing error: {0}")]
+    NFAGraphError(String),
+
+    #[error("JSON parsing error: {0}")]
+    JsonError(String),
+}
+
+pub type ExtractionResult<T> = Result<T, ExtractionError>;
+
+/// Legacy config struct for backward compatibility
+/// Used to convert old-style configs to new enum-based configs
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyRegexPartConfig {
+    pub is_public: bool,
+    pub regex_def: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LegacyDecomposedRegexConfig {
+    pub parts: Vec<LegacyRegexPartConfig>,
+}
+
+impl LegacyRegexPartConfig {
+    /// Convert old struct-based config to new enum-based config
+    pub fn to_new_part(&self, max_bytes: Option<usize>) -> RegexPart {
+        if self.is_public {
+            // For public patterns, use max_bytes or default to 256
+            RegexPart::PublicPattern((self.regex_def.clone(), max_bytes.unwrap_or(256)))
+        } else {
+            RegexPart::Pattern(self.regex_def.clone())
+        }
+    }
+}
+
+impl LegacyDecomposedRegexConfig {
+    /// Convert old config to new config with optional max_bytes per part
+    pub fn to_new_config(&self, max_bytes_per_part: Option<Vec<usize>>) -> DecomposedRegexConfig {
+        let parts = self.parts.iter().enumerate().map(|(i, part)| {
+            let max_bytes = max_bytes_per_part.as_ref().and_then(|v| v.get(i).copied());
+            part.to_new_part(max_bytes)
+        }).collect();
+
+        DecomposedRegexConfig { parts }
+    }
+}

--- a/src/regex/wasm.rs
+++ b/src/regex/wasm.rs
@@ -1,0 +1,197 @@
+use js_sys::Array;
+use wasm_bindgen::prelude::*;
+use serde_wasm_bindgen::{from_value, to_value};
+
+use crate::regex::types::{DecomposedRegexConfig, ExtractionError};
+use crate::regex::extract::{extract_substr_idxes, extract_substr};
+use crate::regex::patterns::*;
+use crate::regex::padding::pad_string;
+
+// Core extraction functions
+// Note: WASM uses standalone mode (no NFAGraph) for simplicity
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractSubstrIdxes(
+    inputStr: &str,
+    regexConfigJson: JsValue,
+    revealPrivate: bool,
+) -> Result<Array, JsValue> {
+    // Parse config from JSON
+    let config: DecomposedRegexConfig = from_value(regexConfigJson)
+        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+
+    // Extract indices (standalone mode - no NFAGraph)
+    let indices = extract_substr_idxes(inputStr, &config, None, revealPrivate)
+        .map_err(|e| JsValue::from_str(&format!("Extraction failed: {}", e)))?;
+
+    // Convert to JS array of [start, end] arrays
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractSubstr(
+    inputStr: &str,
+    regexConfigJson: JsValue,
+    revealPrivate: bool,
+) -> Result<Array, JsValue> {
+    // Parse config from JSON
+    let config: DecomposedRegexConfig = from_value(regexConfigJson)
+        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+
+    // Extract substrings (standalone mode - no NFAGraph)
+    let substrings = extract_substr(inputStr, &config, None, revealPrivate)
+        .map_err(|e| JsValue::from_str(&format!("Extraction failed: {}", e)))?;
+
+    // Convert to JS array
+    let result = Array::new();
+    for s in substrings {
+        result.push(&JsValue::from_str(&s));
+    }
+
+    Ok(result)
+}
+
+// Pre-defined pattern extractors
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractEmailAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_email_addr_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractFromAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_from_addr_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractToAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_to_addr_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractSubjectAllIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_subject_all_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractBodyHashIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_body_hash_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractTimestampIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_timestamp_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn extractMessageIdIdxes(inputStr: &str) -> Result<Array, JsValue> {
+    let indices = extract_message_id_idxes(inputStr)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    let result = Array::new();
+    for (start, end) in indices {
+        let pair = Array::new();
+        pair.push(&JsValue::from(start));
+        pair.push(&JsValue::from(end));
+        result.push(&pair);
+    }
+    Ok(result)
+}
+
+// Padding utilities
+
+#[wasm_bindgen]
+#[allow(non_snake_case)]
+pub fn padString(str: &str, paddedBytesSize: usize) -> Vec<u8> {
+    pad_string(str, paddedBytesSize)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wasm_pad_string() {
+        let result = padString("hello", 10);
+        assert_eq!(result.len(), 10);
+        assert_eq!(&result[0..5], b"hello");
+        assert_eq!(&result[5..10], &[0u8; 5]);
+    }
+}

--- a/src/regex/wasm.rs
+++ b/src/regex/wasm.rs
@@ -1,11 +1,11 @@
 use js_sys::Array;
-use wasm_bindgen::prelude::*;
 use serde_wasm_bindgen::{from_value, to_value};
+use wasm_bindgen::prelude::*;
 
-use crate::regex::types::{DecomposedRegexConfig, ExtractionError};
-use crate::regex::extract::{extract_substr_idxes, extract_substr};
-use crate::regex::patterns::*;
+use crate::regex::extract::{extract_substr, extract_substr_idxes};
 use crate::regex::padding::pad_string;
+use crate::regex::patterns::*;
+use crate::regex::types::{DecomposedRegexConfig, ExtractionError};
 
 // Core extraction functions
 // Note: WASM uses standalone mode (no NFAGraph) for simplicity
@@ -18,15 +18,17 @@ pub fn extractSubstrIdxes(
     revealPrivate: bool,
 ) -> Result<Array, JsValue> {
     // Try parsing as new format first, fall back to legacy format
-    let config: DecomposedRegexConfig = match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
-        Ok(cfg) => cfg,
-        Err(_) => {
-            // Try parsing as legacy format
-            let legacy: crate::regex::types::LegacyDecomposedRegexConfig = from_value(regexConfigJson)
-                .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
-            legacy.to_new_config(None)
-        }
-    };
+    let config: DecomposedRegexConfig =
+        match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
+            Ok(cfg) => cfg,
+            Err(_) => {
+                // Try parsing as legacy format
+                let legacy: crate::regex::types::LegacyDecomposedRegexConfig =
+                    from_value(regexConfigJson)
+                        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+                legacy.to_new_config(None)
+            }
+        };
 
     // Extract indices (standalone mode - no NFAGraph)
     let indices = extract_substr_idxes(inputStr, &config, None, revealPrivate)
@@ -52,15 +54,17 @@ pub fn extractSubstr(
     revealPrivate: bool,
 ) -> Result<Array, JsValue> {
     // Try parsing as new format first, fall back to legacy format
-    let config: DecomposedRegexConfig = match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
-        Ok(cfg) => cfg,
-        Err(_) => {
-            // Try parsing as legacy format
-            let legacy: crate::regex::types::LegacyDecomposedRegexConfig = from_value(regexConfigJson)
-                .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
-            legacy.to_new_config(None)
-        }
-    };
+    let config: DecomposedRegexConfig =
+        match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
+            Ok(cfg) => cfg,
+            Err(_) => {
+                // Try parsing as legacy format
+                let legacy: crate::regex::types::LegacyDecomposedRegexConfig =
+                    from_value(regexConfigJson)
+                        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+                legacy.to_new_config(None)
+            }
+        };
 
     // Extract substrings (standalone mode - no NFAGraph)
     let substrings = extract_substr(inputStr, &config, None, revealPrivate)
@@ -80,8 +84,8 @@ pub fn extractSubstr(
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractEmailAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_email_addr_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_email_addr_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -96,8 +100,8 @@ pub fn extractEmailAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractFromAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_from_addr_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_from_addr_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -112,8 +116,7 @@ pub fn extractFromAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractToAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_to_addr_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices = extract_to_addr_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -128,8 +131,8 @@ pub fn extractToAddrIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractSubjectAllIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_subject_all_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_subject_all_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -144,8 +147,8 @@ pub fn extractSubjectAllIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractBodyHashIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_body_hash_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_body_hash_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -160,8 +163,8 @@ pub fn extractBodyHashIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractTimestampIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_timestamp_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_timestamp_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -176,8 +179,8 @@ pub fn extractTimestampIdxes(inputStr: &str) -> Result<Array, JsValue> {
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 pub fn extractMessageIdIdxes(inputStr: &str) -> Result<Array, JsValue> {
-    let indices = extract_message_id_idxes(inputStr)
-        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let indices =
+        extract_message_id_idxes(inputStr).map_err(|e| JsValue::from_str(&e.to_string()))?;
 
     let result = Array::new();
     for (start, end) in indices {
@@ -212,7 +215,9 @@ mod tests {
     #[test]
     fn test_wasm_extract_substr() {
         let input = "from:alice@example.com";
-        let regex_config_json = JsValue::from_str(r#"{"parts":[{"is_public":true,"regex_def":"[a-z]+@[a-z]+\\.com"}]}"#);
+        let regex_config_json = JsValue::from_str(
+            r#"{"parts":[{"is_public":true,"regex_def":"[a-z]+@[a-z]+\\.com"}]}"#,
+        );
         let result = extractSubstr(input, regex_config_json, false);
         println!("result: {:?}", result);
         assert_eq!(result.unwrap(), vec!["alice@example.com"]);

--- a/src/regex/wasm.rs
+++ b/src/regex/wasm.rs
@@ -5,7 +5,7 @@ use wasm_bindgen::prelude::*;
 use crate::regex::extract::{extract_substr, extract_substr_idxes};
 use crate::regex::padding::pad_string;
 use crate::regex::patterns::*;
-use crate::regex::types::{DecomposedRegexConfig, ExtractionError};
+use crate::regex::types::DecomposedRegexConfig;
 
 // Core extraction functions
 // Note: WASM uses standalone mode (no NFAGraph) for simplicity

--- a/src/regex/wasm.rs
+++ b/src/regex/wasm.rs
@@ -17,9 +17,16 @@ pub fn extractSubstrIdxes(
     regexConfigJson: JsValue,
     revealPrivate: bool,
 ) -> Result<Array, JsValue> {
-    // Parse config from JSON
-    let config: DecomposedRegexConfig = from_value(regexConfigJson)
-        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+    // Try parsing as new format first, fall back to legacy format
+    let config: DecomposedRegexConfig = match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
+        Ok(cfg) => cfg,
+        Err(_) => {
+            // Try parsing as legacy format
+            let legacy: crate::regex::types::LegacyDecomposedRegexConfig = from_value(regexConfigJson)
+                .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+            legacy.to_new_config(None)
+        }
+    };
 
     // Extract indices (standalone mode - no NFAGraph)
     let indices = extract_substr_idxes(inputStr, &config, None, revealPrivate)
@@ -44,9 +51,16 @@ pub fn extractSubstr(
     regexConfigJson: JsValue,
     revealPrivate: bool,
 ) -> Result<Array, JsValue> {
-    // Parse config from JSON
-    let config: DecomposedRegexConfig = from_value(regexConfigJson)
-        .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+    // Try parsing as new format first, fall back to legacy format
+    let config: DecomposedRegexConfig = match from_value::<DecomposedRegexConfig>(regexConfigJson.clone()) {
+        Ok(cfg) => cfg,
+        Err(_) => {
+            // Try parsing as legacy format
+            let legacy: crate::regex::types::LegacyDecomposedRegexConfig = from_value(regexConfigJson)
+                .map_err(|e| JsValue::from_str(&format!("Invalid config: {}", e)))?;
+            legacy.to_new_config(None)
+        }
+    };
 
     // Extract substrings (standalone mode - no NFAGraph)
     let substrings = extract_substr(inputStr, &config, None, revealPrivate)
@@ -193,5 +207,14 @@ mod tests {
         assert_eq!(result.len(), 10);
         assert_eq!(&result[0..5], b"hello");
         assert_eq!(&result[5..10], &[0u8; 5]);
+    }
+
+    #[test]
+    fn test_wasm_extract_substr() {
+        let input = "from:alice@example.com";
+        let regex_config_json = JsValue::from_str(r#"{"parts":[{"is_public":true,"regex_def":"[a-z]+@[a-z]+\\.com"}]}"#);
+        let result = extractSubstr(input, regex_config_json, false);
+        println!("result: {:?}", result);
+        assert_eq!(result.unwrap(), vec!["alice@example.com"]);
     }
 }

--- a/src/regex/wasm.rs
+++ b/src/regex/wasm.rs
@@ -199,27 +199,3 @@ pub fn extractMessageIdIdxes(inputStr: &str) -> Result<Array, JsValue> {
 pub fn padString(str: &str, paddedBytesSize: usize) -> Vec<u8> {
     pad_string(str, paddedBytesSize)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_wasm_pad_string() {
-        let result = padString("hello", 10);
-        assert_eq!(result.len(), 10);
-        assert_eq!(&result[0..5], b"hello");
-        assert_eq!(&result[5..10], &[0u8; 5]);
-    }
-
-    #[test]
-    fn test_wasm_extract_substr() {
-        let input = "from:alice@example.com";
-        let regex_config_json = JsValue::from_str(
-            r#"{"parts":[{"is_public":true,"regex_def":"[a-z]+@[a-z]+\\.com"}]}"#,
-        );
-        let result = extractSubstr(input, regex_config_json, false);
-        println!("result: {:?}", result);
-        assert_eq!(result.unwrap(), vec!["alice@example.com"]);
-    }
-}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -110,7 +110,12 @@ pub async fn generateAccountCode() -> Promise {
 ///
 /// A `Promise` that resolves with the serialized `AccountSalt` or rejects with an error message.
 pub async fn generateAccountSalt(email_addr: String, account_code: String) -> Promise {
-    let email_addr = PaddedEmailAddr::from_email_addr(&email_addr);
+    let email_addr = match PaddedEmailAddr::from_email_addr(&email_addr) {
+        Ok(addr) => addr,
+        Err(e) => {
+            return Promise::reject(&JsValue::from_str(&format!("Invalid email address: {}", e)));
+        }
+    };
     let account_code = match hex_to_field(&account_code) {
         Ok(field) => AccountCode::from(field),
         Err(_) => {
@@ -145,7 +150,12 @@ pub async fn generateAccountSalt(email_addr: String, account_code: String) -> Pr
 ///
 /// A `Promise` that resolves with the serialized padded email address or rejects with an error message.
 pub async fn padEmailAddr(email_addr: String) -> Promise {
-    let padded_email_addr = PaddedEmailAddr::from_email_addr(&email_addr);
+    let padded_email_addr = match PaddedEmailAddr::from_email_addr(&email_addr) {
+        Ok(addr) => addr,
+        Err(e) => {
+            return Promise::reject(&JsValue::from_str(&format!("Invalid email address: {}", e)));
+        }
+    };
     match to_value(&padded_email_addr) {
         Ok(serialized_addr) => Promise::resolve(&serialized_addr),
         Err(_) => Promise::reject(&JsValue::from_str("Failed to serialize padded_email_addr")),
@@ -457,7 +467,12 @@ pub async fn emailAddrCommitWithSignature(email_addr: String, signautre: Vec<u8>
 
     console_error_panic_hook::set_once();
 
-    let padded_email_addr = PaddedEmailAddr::from_email_addr(&email_addr);
+    let padded_email_addr = match PaddedEmailAddr::from_email_addr(&email_addr) {
+        Ok(addr) => addr,
+        Err(e) => {
+            return Promise::reject(&JsValue::from_str(&format!("Invalid email address: {}", e)));
+        }
+    };
     let cm = match padded_email_addr.to_commitment_with_signature(&signautre) {
         Ok(cm) => cm,
         Err(_) => {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -27,9 +27,6 @@ use itertools::Itertools;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::future_to_promise;
 
-#[cfg(target_arch = "wasm32")]
-use zk_regex_apis::extractSubstrIdxes;
-
 #[wasm_bindgen(start)]
 #[cfg(target_arch = "wasm32")]
 pub fn init_panic_hook() {
@@ -548,7 +545,7 @@ pub async fn emailNullifier(mut signautre: Vec<u8>) -> Promise {
 /// A `Promise` that resolves with an array of arrays containing the start and end indices of the invitation code substrings,
 pub fn extractInvitationCodeIdxes(inputStr: &str) -> Result<Array, JsValue> {
     let regex_config = include_str!("../regexes/invitation_code.json");
-    extractSubstrIdxes(inputStr, JsValue::from_str(regex_config), false)
+    crate::regex::wasm::extractSubstrIdxes(inputStr, JsValue::from_str(regex_config), false)
 }
 
 #[wasm_bindgen]
@@ -565,7 +562,7 @@ pub fn extractInvitationCodeIdxes(inputStr: &str) -> Result<Array, JsValue> {
 /// A `Promise` that resolves with an array of arrays containing the start and end indices of the invitation code substrings,
 pub fn extractInvitationCodeWithPrefixIdxes(inputStr: &str) -> Result<Array, JsValue> {
     let regex_config = include_str!("../regexes/invitation_code_with_prefix.json");
-    extractSubstrIdxes(inputStr, JsValue::from_str(regex_config), false)
+    crate::regex::wasm::extractSubstrIdxes(inputStr, JsValue::from_str(regex_config), false)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Description
Adds regex runtime extraction functionality - previously handled on zk-regex and removed from new compiler fresh implementation - this is used to validate text against regex patterns

Fixes # REG-473

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested integration directly from the sdk and registry to make sure the overall flow works

- [x] Integration tests from sdk
- [x] Manually testing from registry

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime regex extraction for common email components (addresses, domain, subject, timestamp, message-id, body hash) with standalone and graph-aligned modes.
  * WebAssembly bindings exposing extraction and padding functions to JS.
  * String and byte padding utilities.
  * Public extraction helpers for common patterns and improved error propagation on email-related operations.

* **Chores**
  * Version bumps (Cargo.toml and package.json) and dependency adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new regex runtime extraction module (Rust + WASM), replaces zk-regex-apis usage, and hardens email handling by validating/piping errors; includes version bumps and dependency updates.
> 
> - **Regex Runtime Extraction (new `src/regex/`)**:
>   - Add `extract`, `patterns`, `padding`, `types`, and WASM bindings providing `extract_substr[_idxes]` and common email pattern helpers.
>   - Support hybrid extraction with optional `NFAGraph`; use `fancy-regex`; define `ExtractionError` and legacy config adapters.
> - **Integration/Refactor**:
>   - Replace `zk_regex_apis` calls with internal `regex` module across `parse_email`, `cryptos`, `circom`, and WASM exports; re-export regex APIs in `lib.rs`.
>   - Add `SerializableRegexPart` and custom serde for `DecomposedRegex.parts`.
> - **Security/Behavior Changes**:
>   - `PaddedEmailAddr::from_email_addr` now validates max length and returns `Result`; propagate in `generate_claim_input`, WASM APIs, and `calculate_account_salt` (now returns `Result`).
> - **Tests**:
>   - Add unit tests for regex extraction, padding, and email length validation/error paths.
> - **Deps/Version**:
>   - Remove `zk-regex-apis`; add `thiserror`, `fancy-regex`; bump crate to `0.4.62-15` and npm to `0.4.66-7`.
> - **Misc**:
>   - `.gitignore`: add `.claude` and `thoughts/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4432090d79187ab8c89bb9a7cd9081d6f9d6db69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->