### PR TITLE
feat: add support for 1024-bit RSA keys in Noir circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3301,7 +3301,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "relayer-utils"
-version = "0.4.62-20"
+version = "0.4.62-21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relayer-utils"
-version = "0.4.62-20"
+version = "0.4.62-21"
 authors = ["Sora Suegami", "Aditya Bisht"]
 license = "MIT"
 edition = "2018"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "wasm:postbuild": "node build.js",
     "build": "npm run wasm:build && npm run wasm:postbuild"
   },
-  "version": "0.4.66-16",
+  "version": "0.4.66-17",
   "devDependencies": {
     "@types/bun": "latest",
     "prettier": "^3.3.3"

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -72,6 +72,7 @@ pub struct CircuitInputWithDecomposedRegexesAndExternalInputsParams {
     pub ignore_body_hash_check: bool,       // Flag to ignore the body hash check
     pub remove_soft_line_breaks: bool,      // Flag to remove soft line breaks from the body
     pub sha_precompute_selector: Option<String>, // Optional regex selector for SHA-256 precomputation
+    pub rsa_key_bits: Option<usize>,        // RSA key size in bits (1024 or 2048), auto-detected if not specified
 }
 
 impl CircuitInputParams {

--- a/src/circuit/noir/mod.rs
+++ b/src/circuit/noir/mod.rs
@@ -21,7 +21,8 @@ use super::{
     ExternalInput,
 };
 
-pub const MODULUS_BITS: usize = 2048;
+/// Default RSA modulus bits (used as fallback)
+pub const DEFAULT_MODULUS_BITS: usize = 2048;
 
 pub async fn generate_noir_circuit_input(
     email: &str,
@@ -31,6 +32,17 @@ pub async fn generate_noir_circuit_input(
     let parsed_email =
         ParsedEmail::new_from_raw_email(email, params.ignore_body_hash_check.unwrap_or(true))
             .await?;
+
+    // Detect key size from public key if not specified
+    // Public key bytes: 128 bytes = 1024 bits, 256 bytes = 2048 bits
+    let key_bits = params.rsa_key_bits.unwrap_or_else(|| {
+        let key_bytes = parsed_email.public_key.len();
+        if key_bytes <= 128 {
+            1024
+        } else {
+            2048
+        }
+    });
 
     // Clone the fields that are used by value before the move occurs
     let public_key = BigUint::from_bytes_be(&parsed_email.public_key)
@@ -65,8 +77,8 @@ pub async fn generate_noir_circuit_input(
 
     // Create the Pubkey struct for the NoirCircuitInput
     let pubkey = Pubkey {
-        modulus: bn_to_limb_str_array(&public_key, Some(MODULUS_BITS)),
-        redc: bn_to_redc_limb_str_array(&public_key, Some(MODULUS_BITS)),
+        modulus: bn_to_limb_str_array(&public_key, Some(key_bits)),
+        redc: bn_to_redc_limb_str_array(&public_key, Some(key_bits)),
     };
 
     // Get the DKIM header sequence
@@ -82,7 +94,7 @@ pub async fn generate_noir_circuit_input(
     };
 
     // Create the BoundedVec for the signature
-    let signature = bn_to_limb_str_array(&signature, Some(MODULUS_BITS));
+    let signature = bn_to_limb_str_array(&signature, Some(key_bits));
 
     // Initialize the NoirCircuitInput struct with required fields
     let mut noir_circuit_input = NoirCircuitInputs {
@@ -233,6 +245,7 @@ pub async fn generate_noir_circuit_inputs_with_regexes_and_external_inputs(
         ignore_body_hash_check: Some(params.ignore_body_hash_check),
         remove_soft_line_breaks: Some(params.remove_soft_line_breaks),
         sha_precompute_selector: params.sha_precompute_selector,
+        rsa_key_bits: params.rsa_key_bits,
         ..Default::default()
     };
     let noir_circuit_input = generate_noir_circuit_input(email, email_circuit_params).await?;

--- a/src/circuit/noir/mod.rs
+++ b/src/circuit/noir/mod.rs
@@ -35,14 +35,23 @@ pub async fn generate_noir_circuit_input(
 
     // Detect key size from public key if not specified
     // Public key bytes: 128 bytes = 1024 bits, 256 bytes = 2048 bits
-    let key_bits = params.rsa_key_bits.unwrap_or_else(|| {
-        let key_bytes = parsed_email.public_key.len();
-        if key_bytes <= 128 {
-            1024
-        } else {
-            2048
+    let key_bits = match params.rsa_key_bits {
+        Some(bits) => bits,
+        None => {
+            let key_bytes = parsed_email.public_key.len();
+            match key_bytes {
+                128 => 1024,
+                256 => 2048,
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Unsupported RSA key size: {} bytes ({} bits). Only 1024-bit and 2048-bit keys are supported.",
+                        key_bytes,
+                        key_bytes * 8
+                    ));
+                }
+            }
         }
-    });
+    };
 
     // Clone the fields that are used by value before the move occurs
     let public_key = BigUint::from_bytes_be(&parsed_email.public_key)

--- a/src/circuit/noir/structs.rs
+++ b/src/circuit/noir/structs.rs
@@ -59,6 +59,8 @@ pub struct NoirInputGenerationArgs {
     pub body_mask: Option<Vec<u8>>,
     pub extract_from: Option<bool>,
     pub extract_to: Option<bool>,
+    /// RSA key size in bits (1024 or 2048). If not specified, auto-detected from public key.
+    pub rsa_key_bits: Option<usize>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

  Adds support for 1024-bit RSA keys in Noir circuit input generation.

  ## Changes

  - Add `rsa_key_bits` parameter to `NoirInputGenerationArgs` and `CircuitInputWithDecomposedRegexesAndExternalInputsParams` to allow specifying RSA key size (1024 or 2048)
  - Auto-detect key size from public key length when not specified:
    - 128 bytes → 1024 bits
    - 256 bytes → 2048 bits
  - Update `generate_noir_circuit_input` to use the detected/specified key size for modulus, redc, and signature calculations
  - Rename `MODULUS_BITS` constant to `DEFAULT_MODULUS_BITS` for clarity

  ## Why

  Some email providers use 1024-bit RSA keys for DKIM signatures. Previously, the Noir circuit input generation only supported 2048-bit keys, causing failures when processing emails signed with 1024-bit keys.

  ## Testing

  The key size is auto-detected from the public key, so existing code continues to work without changes. Users can also explicitly specify `rsa_key_bits` when needed.

  ## Related

  - REG-634